### PR TITLE
Release v0.7.0: Improve installer with option forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,57 @@ AshFeistelCipher is an `Ash.Resource` extension for transforming integer attribu
 
 ## Installation
 
-```
+### Using igniter (Recommended)
+
+```bash
 mix igniter.install ash_feistel_cipher
 ```
+
+You can customize the installation with the following options:
+
+* `--repo` or `-r`: Specify an Ecto repo for FeistelCipher to use.
+* `--functions-prefix` or `-p`: Specify the PostgreSQL schema prefix where the FeistelCipher functions will be created, defaults to `public`.
+* `--functions-salt` or `-s`: Specify the constant value used in the Feistel cipher algorithm. Changing this value will result in different cipher outputs for the same input, should be less than 2^31, defaults to `1_076_943_109`.
+
+Example with custom options:
+
+```bash
+mix igniter.install ash_feistel_cipher --functions-prefix accounts --functions-salt 123456789
+```
+
+### Manual Installation
+
+If you need more control over the installation process, you can install manually:
+
+1. Add `ash_feistel_cipher` to your list of dependencies in `mix.exs`:
+
+   ```elixir
+   def deps do
+     [
+       {:ash_feistel_cipher, "~> 0.7.0"}
+     ]
+   end
+   ```
+
+2. Fetch the dependencies:
+
+   ```bash
+   mix deps.get
+   ```
+
+3. Install FeistelCipher separately with custom options if needed:
+
+   ```bash
+   mix igniter.install feistel_cipher --repo MyApp.Repo --functions-prefix accounts
+   ```
+
+4. Add `:ash_feistel_cipher` to your formatter configuration in `.formatter.exs`:
+
+   ```elixir
+   [
+     import_deps: [:ash_feistel_cipher]
+   ]
+   ```
 
 ## Usage
 

--- a/lib/install.ex
+++ b/lib/install.ex
@@ -18,6 +18,12 @@ defmodule Mix.Tasks.AshFeistelCipher.Install.Docs do
     ```bash
     #{example()}
     ```
+
+    ## Options
+
+    * `--repo` or `-r` — Specify an Ecto repo for FeistelCipher to use.
+    * `--functions-prefix` or `-p` — Specify the PostgreSQL schema prefix where the FeistelCipher functions will be created, defaults to `public`
+    * `--functions-salt` or `-s` — Specify the constant value used in the Feistel cipher algorithm. Changing this value will result in different cipher outputs for the same input, should be less than 2^31, defaults to `#{FeistelCipher.default_functions_salt()}`
     """
   end
 end
@@ -38,7 +44,7 @@ if Code.ensure_loaded?(Igniter) do
         # dependencies to add
         adds_deps: [],
         # dependencies to add and call their associated installers, if they exist
-        installs: [{:feistel_cipher, "~> 0.6.0"}],
+        installs: [{:feistel_cipher, "~> 0.7.0"}],
         # An example invocation
         example: __MODULE__.Docs.example(),
         # A list of environments that this should be installed in.
@@ -47,13 +53,16 @@ if Code.ensure_loaded?(Igniter) do
         positional: [],
         # Other tasks your task composes using `Igniter.compose_task`, passing in the CLI argv
         # This ensures your option schema includes options from nested tasks
-        composes: [],
+        composes: ["feistel_cipher.install"],
         # `OptionParser` schema
-        schema: [],
+        schema: [repo: :string, functions_prefix: :string, functions_salt: :integer],
         # Default values for the options in the `schema`
-        defaults: [],
+        defaults: [
+          functions_prefix: "public",
+          functions_salt: FeistelCipher.default_functions_salt()
+        ],
         # CLI aliases
-        aliases: [],
+        aliases: [r: :repo, p: :functions_prefix, s: :functions_salt],
         # A list of options in the schema that are required
         required: []
       }
@@ -61,10 +70,22 @@ if Code.ensure_loaded?(Igniter) do
 
     @impl Igniter.Mix.Task
     def igniter(igniter) do
-      # Do your work here and return an updated igniter
+      opts = igniter.args.options
+
+      # Compose feistel_cipher.install with the same options
+      feistel_cipher_argv =
+        []
+        |> maybe_add_option("--repo", opts[:repo])
+        |> maybe_add_option("--functions-prefix", opts[:functions_prefix])
+        |> maybe_add_option("--functions-salt", opts[:functions_salt])
+
       igniter
+      |> Igniter.compose_task("feistel_cipher.install", feistel_cipher_argv)
       |> Igniter.Project.Formatter.import_dep(:ash_feistel_cipher)
     end
+
+    defp maybe_add_option(argv, _flag, nil), do: argv
+    defp maybe_add_option(argv, flag, value), do: argv ++ [flag, to_string(value)]
   end
 else
   defmodule Mix.Tasks.AshFeistelCipher.Install do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AshFeistelCipher.MixProject do
   def project do
     [
       app: :ash_feistel_cipher,
-      version: "0.6.0",
+      version: "0.7.0",
       elixir: "~> 1.17",
       consolidate_protocols: Mix.env() not in [:dev, :test],
       start_permanent: Mix.env() == :prod,
@@ -31,7 +31,7 @@ defmodule AshFeistelCipher.MixProject do
   defp deps do
     [
       {:igniter, "~> 0.6", optional: true},
-      {:feistel_cipher, "~> 0.6.0"},
+      {:feistel_cipher, "~> 0.7.0"},
       {:ash, ">= 0.0.0"},
       {:ash_postgres, ">= 0.0.0"},
       {:spark, ">= 0.0.0"},


### PR DESCRIPTION
## Summary

This PR significantly improves the installer by adding option forwarding capabilities and comprehensive documentation. Version bumped to 0.7.0.

## Changes

### Installer Improvements
- **Option Forwarding**: Implemented `compose_task` integration to forward installation options to `feistel_cipher.install`
- **Supported Options**:
  - `--repo` / `-r`: Specify an Ecto repo
  - `--functions-prefix` / `-p`: Specify PostgreSQL schema prefix (default: `public`)
  - `--functions-salt` / `-s`: Specify the cipher salt value (default: `1_076_943_109`)
- **Helper Function**: Added `maybe_add_option/3` to cleanly handle optional parameters

### Documentation
- Added comprehensive installation guide with both igniter and manual installation methods
- Included examples with custom options
- Documented manual installation steps for advanced use cases
- Added formatter configuration instructions

### Dependencies
- Updated `feistel_cipher` dependency from ~> 0.6.0 to ~> 0.7.0
- Updated version from 0.6.0 to 0.7.0

## Benefits

- **Better UX**: Users can now customize FeistelCipher installation options directly when installing ash_feistel_cipher
- **Flexibility**: Supports both automatic installation with options and manual installation for advanced users
- **Consistency**: Aligned with feistel_cipher v0.7.0

## Example Usage

Install with custom options:

```bash
mix igniter.install ash_feistel_cipher --functions-prefix accounts --functions-salt 123456789
```

Or install with default options:

```bash
mix igniter.install ash_feistel_cipher
```

## Breaking Changes

None. This is backward compatible.

