### PR TITLE
Prepare for hex.pm publication

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Jechol Lee <jechol@devall.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,8 @@ defmodule AshFeistelCipher.MixProject do
       consolidate_protocols: Mix.env() not in [:dev, :test],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      description: "Encrypts integer attributes using a Feistel cipher with a Postgres trigger.",
+      description:
+        "Ash extension that transforms integer attributes using a Feistel cipher via Postgres triggers.",
       package: package(),
       source_url: "https://github.com/devall-org/ash_feistel_cipher",
       homepage_url: "https://github.com/devall-org/ash_feistel_cipher",
@@ -32,10 +33,10 @@ defmodule AshFeistelCipher.MixProject do
     [
       {:igniter, "~> 0.6", optional: true},
       {:feistel_cipher, "~> 0.7.0"},
-      {:ash, ">= 0.0.0"},
-      {:ash_postgres, ">= 0.0.0"},
-      {:spark, ">= 0.0.0"},
-      {:sourceror, ">= 0.0.0", optional: true},
+      {:ash, "~> 3.0"},
+      {:ash_postgres, "~> 2.0"},
+      {:spark, "~> 2.0"},
+      {:sourceror, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.29", only: :dev, runtime: false}
     ]
   end
@@ -44,9 +45,11 @@ defmodule AshFeistelCipher.MixProject do
     [
       name: "ash_feistel_cipher",
       licenses: ["MIT"],
+      maintainers: ["Jechol Lee"],
       links: %{
         "GitHub" => "https://github.com/devall-org/ash_feistel_cipher"
-      }
+      },
+      files: ~w(lib mix.exs README.md LICENSE)
     ]
   end
 end


### PR DESCRIPTION
## Changes

- Add MIT LICENSE file with copyright information
- Improve package description to include 'Ash extension' prefix for better discoverability
- Add maintainer information (Jechol Lee)
- Add explicit files list to package configuration
- **Improve dependency version constraints for better forward compatibility:**
  - \`ash\`: \`>= 0.0.0\` → \`~> 3.0\`
  - \`ash_postgres\`: \`>= 0.0.0\` → \`~> 2.0\`
  - \`spark\`: \`>= 0.0.0\` → \`~> 2.0\`
  - \`sourceror\`: \`>= 0.0.0\` → \`~> 1.0\`
  - \`feistel_cipher\`: Kept strict at \`~> 0.7.0\` (0.8+ will not be compatible)

## Purpose

This PR prepares the package for publication to hex.pm with all required metadata, licensing information, and proper dependency version constraints that allow for minor/patch updates while preventing breaking changes.