### PR TITLE
fix: export only locals_without_parens in formatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,12 +8,10 @@ spark_locals_without_parens = [
 ]
 
 [
-  import_deps: [:spark, :reactor, :ash],
   inputs: [
     "{mix,.formatter}.exs",
     "{config,lib,test}/**/*.{ex,exs}"
   ],
-  plugins: [Spark.Formatter],
   locals_without_parens: spark_locals_without_parens,
   export: [
     locals_without_parens: spark_locals_without_parens


### PR DESCRIPTION
## Problem

When users run \`mix igniter.install ash_feistel_cipher\`, the Spark.Formatter plugin was being applied to their entire project, causing unwanted formatting changes to non-Ash code (e.g., migrations).

Example unwanted changes:
\`\`\`elixir
# Before
add :id, :uuid
create unique_index(:users, [:email])

# After (unwanted)
add(:id, :uuid)
create(unique_index(:users, [:email]))
\`\`\`

## Solution

Remove \`import_deps\` and \`plugins\` from \`.formatter.exs\` while keeping the \`export\` configuration intact.

This ensures:
- ✅ ash_feistel_cipher DSL functions (source, target, bits, key, etc.) can still be used without parentheses
- ✅ User projects' existing formatter settings remain untouched
- ✅ Only the necessary \`locals_without_parens\` configuration is exported

## Changes

- Removed \`import_deps: [:spark, :reactor, :ash]\`
- Removed \`plugins: [Spark.Formatter]\`
- Kept \`export: [locals_without_parens: ...]\`