### PR TITLE
chore: release v0.7.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AshFeistelCipher.MixProject do
   def project do
     [
       app: :ash_feistel_cipher,
-      version: "0.7.0",
+      version: "0.7.1",
       elixir: "~> 1.17",
       consolidate_protocols: Mix.env() not in [:dev, :test],
       start_permanent: Mix.env() == :prod,
@@ -32,7 +32,7 @@ defmodule AshFeistelCipher.MixProject do
   defp deps do
     [
       {:igniter, "~> 0.6", optional: true},
-      {:feistel_cipher, "~> 0.7.0"},
+      {:feistel_cipher, "~> 0.7.1"},
       {:ash, "~> 3.0"},
       {:ash_postgres, "~> 2.0"},
       {:spark, "~> 2.0"},


### PR DESCRIPTION
## Changes

- Bump version to 0.7.1
- Require feistel_cipher ~> 0.7.1

## Release Notes

This release includes improvements to the formatter configuration to avoid affecting user projects' non-Ash code:

- Only exports \`locals_without_parens\` settings for ash_feistel_cipher DSL functions
- Removed \`import_deps\` and \`plugins\` from .formatter.exs
- Users can now use DSL functions (source, target, bits, key, etc.) without parentheses
- User projects' existing formatter settings (migrations, etc.) remain untouched

## Dependencies

This version requires \`feistel_cipher ~> 0.7.1\` which includes similar formatter improvements.