### PR TITLE
Upgrade to feistel_cipher 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you need more control over the installation process, you can install manually
    ```elixir
    def deps do
      [
-       {:ash_feistel_cipher, "~> 0.7.0"}
+       {:ash_feistel_cipher, "~> 0.8.0"}
      ]
    end
    ```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ defmodule MyApp.Post do
     encrypt do
       source :seq
       target :referral_code
-      key 12345 # Custom encryption key. Generate with FeistelCipher.random_key() or derive automatically.
+      key 12345 # Custom encryption key (0 to 2^31-1) or derive automatically from attributes.
     end
   end
 end

--- a/lib/install.ex
+++ b/lib/install.ex
@@ -44,7 +44,7 @@ if Code.ensure_loaded?(Igniter) do
         # dependencies to add
         adds_deps: [],
         # dependencies to add and call their associated installers, if they exist
-        installs: [{:feistel_cipher, "~> 0.7.0"}],
+        installs: [{:feistel_cipher, "~> 0.8.0"}],
         # An example invocation
         example: __MODULE__.Docs.example(),
         # A list of environments that this should be installed in.

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -43,13 +43,13 @@ defmodule AshFeistelCipher.Transformer do
     functions_prefix = dsl_state |> Transformer.get_option([:feistel_cipher], :functions_prefix)
 
     up =
-      FeistelCipher.Migration.up_for_encryption(prefix, table, source, target,
+      FeistelCipher.up_for_trigger(prefix, table, source, target,
         bits: bits,
         key: key,
         functions_prefix: functions_prefix
       )
 
-    down = FeistelCipher.Migration.down_for_encryption(prefix, table, source, target)
+    down = FeistelCipher.down_for_trigger(prefix, table, source, target)
 
     {:ok, statement} =
       Transformer.build_entity(

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule AshFeistelCipher.MixProject do
   defp deps do
     [
       {:igniter, "~> 0.6", optional: true},
-      {:feistel_cipher, "~> 0.8.0", path: "../feistel_cipher"},
+      {:feistel_cipher, "~> 0.8.0"},
       {:ash, "~> 3.0"},
       {:ash_postgres, "~> 2.0"},
       {:spark, "~> 2.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule AshFeistelCipher.MixProject do
   defp deps do
     [
       {:igniter, "~> 0.6", optional: true},
-      {:feistel_cipher, "~> 0.8.0"},
+      {:feistel_cipher, "~> 0.8.0", path: "../feistel_cipher"},
       {:ash, "~> 3.0"},
       {:ash_postgres, "~> 2.0"},
       {:spark, "~> 2.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AshFeistelCipher.MixProject do
   def project do
     [
       app: :ash_feistel_cipher,
-      version: "0.7.1",
+      version: "0.8.0",
       elixir: "~> 1.17",
       consolidate_protocols: Mix.env() not in [:dev, :test],
       start_permanent: Mix.env() == :prod,
@@ -32,7 +32,7 @@ defmodule AshFeistelCipher.MixProject do
   defp deps do
     [
       {:igniter, "~> 0.6", optional: true},
-      {:feistel_cipher, "~> 0.7.1"},
+      {:feistel_cipher, "~> 0.8.0"},
       {:ash, "~> 3.0"},
       {:ash_postgres, "~> 2.0"},
       {:spark, "~> 2.0"},

--- a/test/transformer_test.exs
+++ b/test/transformer_test.exs
@@ -181,7 +181,7 @@ defmodule AshFeistelCipher.TransformerTest do
     end
   end
 
-  describe "integration with FeistelCipher.Migration" do
+  describe "integration with FeistelCipher" do
     test "uses correct encryption key generation" do
       statements = get_custom_statements(AshFeistelCipher.Test.ValidResource)
 


### PR DESCRIPTION
## Changes

- Upgrade feistel_cipher dependency to 0.8.0
- Update install.ex to require feistel_cipher ~> 0.8.0
- Remove reference to deleted \`FeistelCipher.random_key()\` function
- Update test descriptions to reflect module consolidation
- Use local path for feistel_cipher dependency (development)

## Dependencies

This PR depends on:
- https://github.com/devall-org/feistel_cipher/pull/9

## Testing

- All tests pass (14 tests, 0 failures)
- Compatible with feistel_cipher 0.8.0