### PR TITLE
Update to renamed feistel_cipher trigger functions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,7 +38,7 @@ This composes `feistel_cipher.upgrade` to generate an Ecto migration template. E
 mix ash.codegen --name upgrade_feistel_v1
 ```
 
-In the generated migration, replace `down_for_v1_trigger` with `force_down_for_legacy_trigger` in the `up` function (to drop legacy triggers).
+In the generated migration's `up` function, replace `down_for_trigger` (or `down_for_v1_trigger`) with `force_down_for_legacy_trigger` to drop legacy triggers. Also in the `down` function, replace `up_for_trigger` with `up_for_legacy_trigger` and `bits:` with `time_bits: 0, data_bits:`.
 
 ---
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -35,7 +35,7 @@ This composes `feistel_cipher.upgrade` to generate an Ecto migration template. E
 3. **Regenerate Ash migrations**:
 
 ```bash
-mix ash.codegen --name upgrade_feistel_v1
+mix ash.codegen --name upgrade_feistel_triggers_to_v1
 ```
 
 In the generated migration's `up` function, replace `down_for_trigger` (or `down_for_v1_trigger`) with `force_down_for_legacy_trigger` to drop legacy triggers. Also in the `down` function, replace `up_for_trigger` with `up_for_legacy_trigger` and `bits:` with `time_bits: 0, data_bits:`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -35,8 +35,10 @@ This composes `feistel_cipher.upgrade` to generate an Ecto migration template. E
 3. **Regenerate Ash migrations**:
 
 ```bash
-mix ash.codegen upgrade_feistel_cipher
+mix ash.codegen --name upgrade_feistel_v1
 ```
+
+In the generated migration, replace `down_for_v1_trigger` with `force_down_for_legacy_trigger` in the `up` function (to drop legacy triggers).
 
 ---
 

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -54,7 +54,7 @@ defmodule AshFeistelCipher.Transformer do
 
     up = """
     execute(
-      FeistelCipher.up_for_trigger(#{inspect(prefix)}, #{inspect(table)}, #{inspect(from_column)}, #{inspect(to_column)},
+      FeistelCipher.up_for_v1_trigger(#{inspect(prefix)}, #{inspect(table)}, #{inspect(from_column)}, #{inspect(to_column)},
         time_bits: #{time_bits},
         time_bucket: #{time_bucket},
         encrypt_time: #{encrypt_time},
@@ -68,7 +68,7 @@ defmodule AshFeistelCipher.Transformer do
 
     down = """
     execute(
-      FeistelCipher.down_for_trigger(#{inspect(prefix)}, #{inspect(table)}, #{inspect(from_column)}, #{inspect(to_column)})
+      FeistelCipher.down_for_v1_trigger(#{inspect(prefix)}, #{inspect(table)}, #{inspect(from_column)}, #{inspect(to_column)})
     )
     """
 


### PR DESCRIPTION
## Summary

- Update transformer to use `up_for_v1_trigger` / `down_for_v1_trigger` (was `up_for_trigger` / `down_for_trigger`)
- Update UPGRADE.md with correct instruction: replace `down_for_v1_trigger` with `force_down_for_legacy_trigger`
- Depends on devall-org/feistel_cipher#27

## Test plan

- [ ] Verify compilation with updated feistel_cipher dependency
- [ ] Test upgrade flow with corki

🤖 Generated with [Claude Code](https://claude.com/claude-code)