### PR TITLE
Change default time_bucket from 86400 to 3600

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ defmodule MyApp.Repo.Migrations.CreatePost do
     execute(
       FeistelCipher.up_for_trigger("public", "posts", "seq", "id",
         time_bits: 12,
-        time_bucket: 86400,
+        time_bucket: 3600,
         encrypt_time: false,
         data_bits: 40,
         key: 1_984_253_769,
@@ -229,7 +229,7 @@ Required:
 
 Optional (⚠️ **Cannot be changed after records are created**):
 - `time_bits` (default: 12): Time prefix bits for backup optimization. Set to 0 for no time prefix
-- `time_bucket` (default: 86400): Time bucket size in seconds
+- `time_bucket` (default: 3600): Time bucket size in seconds
 - `encrypt_time` (default: false): Whether to encrypt the time prefix
 - `data_bits` (default: 40): Data encryption bit size (must be even)
 - `key`: Custom encryption key (auto-generated from table/column names if not provided)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,7 +5,7 @@
 ### What changed
 
 - **`bits` option renamed to `data_bits`** (default changed from 52 to 40)
-- **New DSL options**: `time_bits` (default: 12), `time_bucket` (default: 86400), `encrypt_time` (default: false)
+- **New DSL options**: `time_bits` (default: 12), `time_bucket` (default: 3600), `encrypt_time` (default: false)
 - **Depends on `feistel_cipher ~> 1.0`** (PG functions use `_v1` suffix)
 
 ### Steps

--- a/lib/ash_feistel_cipher.ex
+++ b/lib/ash_feistel_cipher.ex
@@ -107,9 +107,9 @@ defmodule AshFeistelCipher do
     ],
     time_bucket: [
       type: :integer,
-      default: 86400,
+      default: 3600,
       doc:
-        "Time bucket size in seconds for the time prefix. Default is 86400 (1 day). Cannot be changed after records are created."
+        "Time bucket size in seconds for the time prefix. Default is 3600 (1 hour). Cannot be changed after records are created."
     ],
     encrypt_time: [
       type: :boolean,

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -42,7 +42,7 @@ defmodule AshFeistelCipher.Transformer do
 
     # Apply defaults at compile time
     time_bits = time_bits || 12
-    time_bucket = time_bucket || 86400
+    time_bucket = time_bucket || 3600
     encrypt_time = if is_nil(encrypt_time), do: false, else: encrypt_time
     data_bits = data_bits || 40
     rounds = rounds || 16


### PR DESCRIPTION
## Summary
- Change default `time_bucket` from 86400 (1 day) to 3600 (1 hour)
- Align with feistel_cipher v1.0 default for better ID space utilization
- Updated lib, transformer, and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)