### PR TITLE
Use DSL defaults as SSOT for feistel options

### DIFF
--- a/lib/ash_feistel_cipher.ex
+++ b/lib/ash_feistel_cipher.ex
@@ -153,6 +153,14 @@ defmodule AshFeistelCipher do
     ]
   ]
 
+  @feistel_default_options_map (for {name, config} <- @feistel_options,
+                                    Keyword.has_key?(config, :default),
+                                    into: %{} do
+                                  {name, Keyword.fetch!(config, :default)}
+                                end)
+
+  def feistel_default_options, do: @feistel_default_options_map
+
   @encrypted_integer %Spark.Dsl.Entity{
     name: :encrypted_integer,
     describe: """


### PR DESCRIPTION
## Summary
- centralize Feistel option default values in `AshFeistelCipher` so defaults come from a single source of truth
- remove duplicated compile-time fallback defaults from `AshFeistelCipher.Transformer` and merge extension defaults with attribute options for compatibility
- keep runtime key auto-generation behavior intact when `key` is not explicitly provided

## Verification
- `mix test` (ash_feistel_cipher): 34 tests, 0 failures
- `direnv exec . mix ash.codegen --check` (bard): no changes reported