### PR TITLE
Version generated custom statement names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@
 
 - Added the FeistelCipher major version to generated custom statement names.
 
-## 1.0.0
-
-- Renamed `bits` to `data_bits`.
-- Added `time_bits`, `time_bucket`, and `encrypt_time` options.
-- Switched to `feistel_cipher` v1 PG function and trigger flow.
-- Recommended new default profile: `time_bits: 15`, `data_bits: 38`.
-
 ## 1.1.0
 
 - Added `backfill?` support for `encrypted_integer` and `encrypted_integer_primary_key`.
@@ -18,3 +11,10 @@
 - `encrypted_integer` now uses an internal sentinel default to avoid `bigserial` generation.
 - User-provided `default:` is no longer supported for `encrypted_integer`.
 - Generated custom statement names now include both `from` and `to`, which may cause migration and snapshot churn.
+
+## 1.0.0
+
+- Renamed `bits` to `data_bits`.
+- Added `time_bits`, `time_bucket`, and `encrypt_time` options.
+- Switched to `feistel_cipher` v1 PG function and trigger flow.
+- Recommended new default profile: `time_bits: 15`, `data_bits: 38`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1
 
-- Added the FeistelCipher PostgreSQL API version to generated custom statement names.
+- Added the FeistelCipher major version to generated custom statement names.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1
 
-- Added the cipher version to generated custom statement names.
+- Added the FeistelCipher PostgreSQL API version to generated custom statement names.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+
+- Added the cipher version to generated custom statement names.
+
 ## 1.0.0
 
 - Renamed `bits` to `data_bits`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you need more control over the installation process, you can install manually
    ```elixir
    def deps do
      [
-       {:ash_feistel_cipher, "~> 1.1"}
+       {:ash_feistel_cipher, "~> 1.1.1"}
      ]
    end
    ```

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -78,7 +78,7 @@ defmodule AshFeistelCipher.Transformer do
         AshPostgres.DataLayer,
         [:postgres, :custom_statements],
         :statement,
-        name: custom_statement_name(:feistel_cipher_trigger, from_attr, to_attr),
+        name: custom_statement_name(:feistel_cipher_v1_trigger, from_attr, to_attr),
         code?: true,
         up: up,
         down: down
@@ -109,7 +109,7 @@ defmodule AshFeistelCipher.Transformer do
           AshPostgres.DataLayer,
           [:postgres, :custom_statements],
           :statement,
-          name: custom_statement_name(:feistel_cipher_backfill, from_attr, to_attr),
+          name: custom_statement_name(:feistel_cipher_v1_backfill, from_attr, to_attr),
           code?: true,
           up: backfill_up,
           down: ""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AshFeistelCipher.MixProject do
   def project do
     [
       app: :ash_feistel_cipher,
-      version: "1.1.0",
+      version: "1.1.1",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       consolidate_protocols: Mix.env() not in [:dev, :test],

--- a/test/transformer_test.exs
+++ b/test/transformer_test.exs
@@ -2,7 +2,7 @@ defmodule AshFeistelCipher.TransformerTest do
   use ExUnit.Case, async: true
 
   # Helper to get custom statements from a resource
-  defp get_custom_statements(resource, name \\ :feistel_cipher_trigger_seq_to_id) do
+  defp get_custom_statements(resource, name \\ :feistel_cipher_v1_trigger_seq_to_id) do
     resource
     |> AshPostgres.DataLayer.Info.custom_statements()
     |> Enum.filter(&(&1.name == name))
@@ -33,13 +33,13 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.ValidResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
       [statement] = statements
 
-      assert statement.name == :feistel_cipher_trigger_seq_to_id
+      assert statement.name == :feistel_cipher_v1_trigger_seq_to_id
       assert statement.code? == true
       assert statement.up != nil
       assert statement.down != nil
@@ -71,7 +71,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.MultipleEncryptsResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 2
@@ -100,7 +100,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.CustomBitsResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -113,7 +113,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.CustomKeyResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -126,7 +126,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.CustomRoundsResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -140,7 +140,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.CustomTimeOffsetResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -154,7 +154,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.ValidResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -168,7 +168,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.CustomFunctionsPrefixResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -182,7 +182,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.CustomSchemaResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -197,7 +197,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.CustomSourceResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -214,7 +214,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.TimeBitsZeroResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -232,7 +232,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.ValidResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -249,7 +249,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.MultipleEncryptsResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 2
@@ -266,13 +266,13 @@ defmodule AshFeistelCipher.TransformerTest do
       trigger_statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.ValidResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       backfill_statements =
         get_custom_statements(
           AshFeistelCipher.Test.ValidResource,
-          :feistel_cipher_backfill_seq_to_id
+          :feistel_cipher_v1_backfill_seq_to_id
         )
 
       assert length(trigger_statements) == 1
@@ -289,13 +289,13 @@ defmodule AshFeistelCipher.TransformerTest do
       trigger_statements =
         get_custom_statements(
           AshFeistelCipher.Test.BackfillExistingResource,
-          :feistel_cipher_trigger_seq_to_id_10
+          :feistel_cipher_v1_trigger_seq_to_id_10
         )
 
       backfill_statements =
         get_custom_statements(
           AshFeistelCipher.Test.BackfillExistingResource,
-          :feistel_cipher_backfill_seq_to_id_10
+          :feistel_cipher_v1_backfill_seq_to_id_10
         )
 
       assert length(trigger_statements) == 1
@@ -317,13 +317,13 @@ defmodule AshFeistelCipher.TransformerTest do
       trigger_statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.NoBackfillResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       backfill_statements =
         get_custom_statements(
           AshFeistelCipher.Test.NoBackfillResource,
-          :feistel_cipher_backfill_seq_to_id
+          :feistel_cipher_v1_backfill_seq_to_id
         )
 
       assert length(trigger_statements) == 1
@@ -336,7 +336,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.ValidResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       [statement] = statements
@@ -355,7 +355,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.CustomKeyResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       [statement] = statements
@@ -378,7 +378,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.PrimaryKeyResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1
@@ -404,7 +404,7 @@ defmodule AshFeistelCipher.TransformerTest do
       statements =
         get_trigger_statements_by_prefix(
           AshFeistelCipher.Test.PrimaryKeyCustomOptionsResource,
-          :feistel_cipher_trigger
+          :feistel_cipher_v1_trigger
         )
 
       assert length(statements) == 1


### PR DESCRIPTION
- Include `v1` in generated trigger and backfill custom statement names.
- Keep statement identities aligned with the versioned `FeistelCipher.*_for_v1_*` migration helpers.
- Bump the package version to 1.1.1.

Validation:
- `mix format --check-formatted`
- `mix test test/transformer_test.exs` (22 tests, 0 failures)